### PR TITLE
Closes #2 By Adding TemplateSource 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.docutools'
-version '1.0.2'
+version '1.0.3'
 
 sourceCompatibility = 14
 targetCompatibility = 14

--- a/src/main/java/com/docutools/jocument/Template.java
+++ b/src/main/java/com/docutools/jocument/Template.java
@@ -59,7 +59,7 @@ public interface Template {
    * Creates a {@link Template} instance from a file.
    *
    * @param path the file path
-   * @return the {@link Template} when the file was found
+   * @return the {@link Template} where the file was found
    */
   static Optional<Template> from(Path path) {
     return from(path, LocaleUtil.getUserLocale());
@@ -69,7 +69,7 @@ public interface Template {
    * Creates a {@link Template} instance from a file.
    *
    * @param path the file path
-   * @param locale the templates {@link Locale}
+   * @param locale of templates {@link Locale}
    * @return the {@link Template} when the file was found
    */
   static Optional<Template> from(Path path, Locale locale) {

--- a/src/main/java/com/docutools/jocument/Template.java
+++ b/src/main/java/com/docutools/jocument/Template.java
@@ -1,10 +1,18 @@
 package com.docutools.jocument;
 
 import com.docutools.jocument.impl.TemplateImpl;
+import com.docutools.jocument.impl.template.InMemoryTemplateSource;
+import com.docutools.jocument.impl.template.PathTemplateSource;
+import com.docutools.jocument.impl.template.URLTemplateSource;
 import org.apache.poi.util.LocaleUtil;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -44,7 +52,131 @@ public interface Template {
     var mimeType = MimeType.fromFileExtension(path)
             .orElseThrow(() -> new IllegalArgumentException("Unsupported MIME-Type: " + path));
     return Optional.ofNullable(Template.class.getResource(path))
-            .map(url -> new TemplateImpl(url, mimeType, locale));
+            .map(url -> new TemplateImpl(new URLTemplateSource(url), mimeType, locale));
+  }
+
+  /**
+   * Creates a {@link Template} instance from a file.
+   *
+   * @param path the file path
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(Path path) {
+    return from(path, LocaleUtil.getUserLocale());
+  }
+
+  /**
+   * Creates a {@link Template} instance from a file.
+   *
+   * @param path the file path
+   * @param locale the templates {@link Locale}
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(Path path, Locale locale) {
+    var mimeType = MimeType.fromFileExtension(path.toString())
+            .orElseThrow(() -> new IllegalArgumentException("Unsupported MIME-Type: " + path));
+    return Optional.of(new TemplateImpl(new PathTemplateSource(path), mimeType, locale));
+  }
+
+  /**
+   * Creates a {@link Template} instance from a file.
+   *
+   * @param file the file path
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(File file) {
+    return from(file.toPath());
+  }
+
+  /**
+   * Creates a {@link Template} instance from a file.
+   *
+   * @param file the file path
+   * @param locale the templates {@link Locale}
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(File file, Locale locale) {
+    return from(file.toPath(), locale);
+  }
+
+  /**
+   * Creates a {@link Template} instance from a URL.
+   *
+   * @param url the url
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(URL url) {
+    return from(url, LocaleUtil.getUserLocale());
+  }
+
+  /**
+   * Creates a {@link Template} instance from a URL.
+   *
+   * @param url the URL
+   * @param locale the templates {@link Locale}
+   * @return the {@link Template} when the file was found
+   */
+  static Optional<Template> from(URL url, Locale locale) {
+    var mimeType = MimeType.fromFileExtension(url.getPath())
+            .orElseThrow(() -> new IllegalArgumentException("Unsupported MIME-Type: " + url));
+    return Optional.of(new TemplateImpl(new URLTemplateSource(url), mimeType, locale));
+  }
+
+  /**
+   * Creates a {@link Template} from an URI.
+   *
+   * @param uri the URI
+   * @return the {@link Template}
+   * @throws MalformedURLException when the uri does not contain an absolute path
+   */
+  static Optional<Template> from(URI uri) throws MalformedURLException {
+    return from(uri.toURL());
+  }
+
+  /**
+   * Creates an in-memory representation of a {@link Template}.
+   *
+   * @param data the template file data
+   * @param mimeType it's MIME Type
+   * @return the in-memory {@link Template}
+   */
+  static Optional<Template> from(byte[] data, MimeType mimeType) {
+    return from(data, mimeType, LocaleUtil.getUserLocale());
+  }
+
+  /**
+   * Creates an in-memory representation of a {@link Template}.
+   *
+   * @param data the template file data
+   * @param locale the {@link Locale}
+   * @param mimeType it's MIME Type
+   * @return the in-memory {@link Template}
+   */
+  static Optional<Template> from(byte[] data, MimeType mimeType, Locale locale) {
+    return Optional.of(new TemplateImpl(new InMemoryTemplateSource(data), mimeType, locale));
+  }
+
+  /**
+   * Creates an in-memory representation of a {@link Template}.
+   *
+   * @param in the template file data
+   * @param mimeType it's MIME Type
+   * @return the in-memory {@link Template}
+   */
+  static Optional<Template> from(InputStream in, MimeType mimeType) throws IOException {
+    return from(in, mimeType, LocaleUtil.getUserLocale());
+  }
+
+  /**
+   * Creates an in-memory representation of a {@link Template}.
+   *
+   * @param in the template file data
+   * @param mimeType it's MIME Type
+   * @param locale it's {@link Locale}
+   * @return the in-memory {@link Template}
+   */
+  static Optional<Template> from(InputStream in, MimeType mimeType, Locale locale) throws IOException {
+    return Optional.of(new TemplateImpl(new InMemoryTemplateSource(in), mimeType, locale));
   }
 
   /**

--- a/src/main/java/com/docutools/jocument/TemplateSource.java
+++ b/src/main/java/com/docutools/jocument/TemplateSource.java
@@ -1,0 +1,10 @@
+package com.docutools.jocument;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface TemplateSource {
+
+    InputStream open() throws IOException;
+
+}

--- a/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/TemplateImpl.java
@@ -1,9 +1,6 @@
 package com.docutools.jocument.impl;
 
-import com.docutools.jocument.Document;
-import com.docutools.jocument.MimeType;
-import com.docutools.jocument.PlaceholderResolver;
-import com.docutools.jocument.Template;
+import com.docutools.jocument.*;
 import com.docutools.jocument.impl.excel.implementations.ExcelDocumentImpl;
 import com.docutools.jocument.impl.word.WordDocumentImpl;
 import org.apache.logging.log4j.LogManager;
@@ -17,12 +14,12 @@ import java.util.Locale;
 public class TemplateImpl implements Template {
     private static final Logger logger = LogManager.getLogger();
 
-  private final URL url;
+    private final TemplateSource source;
   private final MimeType mimeType;
   private final Locale locale;
 
-  public TemplateImpl(URL url, MimeType mimeType, Locale locale) {
-    this.url = url;
+  public TemplateImpl(TemplateSource source, MimeType mimeType, Locale locale) {
+    this.source = source;
     this.mimeType = mimeType;
     this.locale = locale;
   }
@@ -51,6 +48,6 @@ public class TemplateImpl implements Template {
 
   @Override
   public InputStream openStream() throws IOException {
-    return url.openStream();
+    return source.open();
   }
 }

--- a/src/main/java/com/docutools/jocument/impl/template/InMemoryTemplateSource.java
+++ b/src/main/java/com/docutools/jocument/impl/template/InMemoryTemplateSource.java
@@ -1,0 +1,26 @@
+package com.docutools.jocument.impl.template;
+
+import com.docutools.jocument.TemplateSource;
+
+import java.io.*;
+
+public class InMemoryTemplateSource implements TemplateSource {
+
+    private final byte[] data;
+
+    public InMemoryTemplateSource(byte[] data) {
+        this.data = data;
+    }
+
+    public InMemoryTemplateSource(InputStream in) throws IOException {
+        try(var bos = new ByteArrayOutputStream()) {
+            in.transferTo(bos);
+            this.data = bos.toByteArray();
+        }
+    }
+
+    @Override
+    public InputStream open() throws IOException {
+        return new ByteArrayInputStream(data);
+    }
+}

--- a/src/main/java/com/docutools/jocument/impl/template/PathTemplateSource.java
+++ b/src/main/java/com/docutools/jocument/impl/template/PathTemplateSource.java
@@ -1,0 +1,28 @@
+package com.docutools.jocument.impl.template;
+
+import com.docutools.jocument.TemplateSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class PathTemplateSource implements TemplateSource {
+
+    private final Path path;
+
+    public PathTemplateSource(Path path) {
+        this.path = path;
+    }
+
+    public PathTemplateSource(File file) {
+        this.path = file.toPath();
+    }
+
+    @Override
+    public InputStream open() throws IOException {
+        return Files.newInputStream(path, StandardOpenOption.READ);
+    }
+}

--- a/src/main/java/com/docutools/jocument/impl/template/URLTemplateSource.java
+++ b/src/main/java/com/docutools/jocument/impl/template/URLTemplateSource.java
@@ -1,0 +1,27 @@
+package com.docutools.jocument.impl.template;
+
+import com.docutools.jocument.TemplateSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+public class URLTemplateSource implements TemplateSource {
+
+    private final URL url;
+
+    public URLTemplateSource(URI uri) throws MalformedURLException {
+        this.url = uri.toURL();
+    }
+
+    public URLTemplateSource(URL url) {
+        this.url = url;
+    }
+
+    @Override
+    public InputStream open() throws IOException {
+        return url.openStream();
+    }
+}

--- a/src/test/java/com/docutools/jocument/TemplateLoading.java
+++ b/src/test/java/com/docutools/jocument/TemplateLoading.java
@@ -1,0 +1,101 @@
+package com.docutools.jocument;
+
+import org.apache.poi.util.LocaleUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@DisplayName("Template Loading")
+public class TemplateLoading {
+
+    @Test
+    @DisplayName("Load word templates from classpath.")
+    void shouldLoadWordTemplateFromCP() {
+        // Act
+        Template template = Template.fromClassPath("/templates/word/UserProfileTemplate.docx")
+                .orElseThrow();
+
+        // Assert
+        assertThat(template.getMimeType(), is(MimeType.DOCX));
+    }
+
+    @Test
+    @DisplayName("Return empty value when given classpath resource does not exist.")
+    void shouldReturnEmptyWhenCpNotExists() {
+        // Act
+        var result = Template.fromClassPath("/does/not/exist.docx");
+
+        // Assert
+        assertThat(result.isEmpty(), is(true));
+    }
+
+    @Test
+    @DisplayName("Load word templates from the file system.")
+    void shouldLoadWordTemplatesFromFs() throws IOException {
+        // Arrange
+        Path path = null;
+        try {
+            path = Files.createTempFile("jocument", ".docx");
+            try(var in = getClass().getResourceAsStream("/templates/word/UserProfileTemplate.docx")) {
+                Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            var result = Template.from(path);
+            assertThat(result.isEmpty(), is(false));
+        } finally {
+            if(path != null) {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Template should assume systems default Locale, if none is passed with resource.")
+    void shouldAssumeDefaultLocale() {
+        // Act
+        var result = Template.fromClassPath("/templates/word/UserProfileTemplate.docx")
+                .orElseThrow();
+
+        // Assert
+        assertThat(result.getLocale(), equalTo(LocaleUtil.getUserLocale()));
+    }
+
+    @Test
+    @DisplayName("Load Template from Byte Array")
+    void shouldLoadTemplateFromByteArray() throws IOException {
+        // Arrange
+        byte[] data;
+        try(var in = getClass().getResourceAsStream("/templates/word/UserProfileTemplate.docx")) {
+            try(var out = new ByteArrayOutputStream()) {
+                in.transferTo(out);
+                data = out.toByteArray();
+            }
+        }
+
+        // Act
+        Template.from(data, MimeType.DOCX)
+                .orElseThrow();
+    }
+
+    @Test
+    @DisplayName("Load Template from InputStream")
+    void shouldLoadTemplateFromInputStream() throws IOException {
+        // Arrange + Act
+        try(var in = getClass().getResourceAsStream("/templates/word/UserProfileTemplate.docx")) {
+            Template.from(in, MimeType.DOCX)
+                    .orElseThrow();
+        }
+    }
+}

--- a/src/test/java/com/docutools/jocument/WordDocuments.java
+++ b/src/test/java/com/docutools/jocument/WordDocuments.java
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,37 +21,6 @@ import static org.hamcrest.Matchers.is;
 @DisplayName("Generating Word Documents")
 public class WordDocuments {
 
-  @Test
-  @DisplayName("Load word templates from classpath.")
-  void shouldLoadWordTemplateFromCP() {
-    // Act
-    Template template = Template.fromClassPath("/templates/word/UserProfileTemplate.docx")
-            .orElseThrow();
-
-    // Assert
-    assertThat(template.getMimeType(), is(MimeType.DOCX));
-  }
-
-  @Test
-  @DisplayName("Return empty value when given classpath resource does not exist.")
-  void shouldReturnEmptyWhenCpNotExists() {
-    // Act
-    var result = Template.fromClassPath("/does/not/exist.docx");
-
-    // Assert
-    assertThat(result.isEmpty(), is(true));
-  }
-
-  @Test
-  @DisplayName("Template should assume systems default Locale, if none is passed with resource.")
-  void shouldAssumeDefaultLocale() {
-    // Act
-    var result = Template.fromClassPath("/templates/word/UserProfileTemplate.docx")
-            .orElseThrow();
-
-    // Assert
-    assertThat(result.getLocale(), equalTo(LocaleUtil.getUserLocale()));
-  }
 
   @Test
   @DisplayName("Generate a document from a simple template.")


### PR DESCRIPTION
To allow multiple sources for template files (FS, net, in memory) I introduced a new class called `TemplateSource` with multiple impls (`InMemoryTemplateSource`, ...) accepted by `TemplateImpl` instead of simply `URL`. The `Template` interface has new factory methods using the various `TemplateSource` impls.