### PR TITLE
 Introduce owasp dependency-check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'checkstyle'
     id "org.sonarqube" version "2.8"
-    id "org.owasp.dependencycheck" version "5.2.4"
+    id "org.owasp.dependencycheck" version "5.3.2"
 }
 
 group 'com.docutools'
@@ -24,10 +24,10 @@ dependencies {
     implementation("org.apache.poi:poi-ooxml-schemas:4.1.2")
 
     implementation("com.google.code.gson:gson:2.8.6")
-    implementation("org.apache.tika:tika-core:1.23")
+    implementation("org.apache.tika:tika-core:1.24.1")
 
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.1'
-    runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.3'
+    runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.3'
 
     implementation 'com.codepoetics:protonpack:1.16'
     implementation("com.google.guava:guava:29.0-jre")


### PR DESCRIPTION
This commit activates owasp dependency check, a security
library which analyzes dependencies for advised critical
vulnerabilities.
It additionally fixes two found insecure versions (apache
tika and log4j)

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>