### PR TITLE
Enable owasp dependency check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Check a new push for conforming to style requirements
+name: Check a new push for conforming to style and security requirements
 
 on: push
 
@@ -16,4 +16,20 @@ jobs:
         with:
           java-version: 15
       - name: Run checkstyle
-        run: ./gradlew checkMain checkTest
+        uses: eskatos/gradle-command-action@v1
+          with:
+            arguments: checkMain checkTest
+    owasp:
+      name: Check whether code confirms to owasp security requirements
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Setup Java
+          uses: actions/setup-java@v1
+          with:
+            java-version: 15
+        - name: Run owasp dependency check
+          uses: eskatos/gradle-command-action@v1
+            with:
+              arguments: dependencyCheckAnalyze

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,8 +17,8 @@ jobs:
           java-version: 15
       - name: Run checkstyle
         uses: eskatos/gradle-command-action@v1
-          with:
-            arguments: checkMain checkTest
+        with:
+          arguments: checkMain checkTest
     owasp:
       name: Check whether code confirms to owasp security requirements
       runs-on: ubuntu-latest
@@ -31,5 +31,5 @@ jobs:
             java-version: 15
         - name: Run owasp dependency check
           uses: eskatos/gradle-command-action@v1
-            with:
-              arguments: dependencyCheckAnalyze
+          with:
+            arguments: dependencyCheckAnalyze

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Check a new push for conforming to style and security requirements
+name: Check push for conforming to style and security requirements
 
 on: push
 
@@ -19,17 +19,17 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: checkMain checkTest
-    owasp:
-      name: Check whether code confirms to owasp security requirements
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
-        - name: Setup Java
-          uses: actions/setup-java@v1
-          with:
-            java-version: 15
-        - name: Run owasp dependency check
-          uses: eskatos/gradle-command-action@v1
-          with:
-            arguments: dependencyCheckAnalyze
+  owasp:
+    name: Check whether code confirms to owasp security requirements
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: Run owasp dependency check
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: dependencyCheckAnalyze

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'checkstyle'
     id "org.sonarqube" version "2.8"
-    id "org.owasp.dependencycheck" version "5.3.2"
+    id "org.owasp.dependencycheck" version "6.0.2"
     id 'maven-publish'
 }
 


### PR DESCRIPTION
This commit enables the owasp dependency check in
the github push action and additionally updates
the plugin

Related to #6 

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>