### PR TITLE
Fix function counting full cells

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.docutools'
-version '1.0.13'
+version '1.0.14'
 
 sourceCompatibility = 15
 targetCompatibility = 15

--- a/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelGenerator.java
@@ -154,7 +154,7 @@ public class ExcelGenerator {
 
 
   private boolean isLoopStart(Row row) {
-    if (getNumberOfNonEmptyCells(row) == 1) {
+    if (ExcelUtils.getNumberOfNonEmptyCells(row) == 1) {
       var cell = row.getCell(row.getFirstCellNum());
       if (cell.getCellType() == CellType.STRING) {
         return resolver.resolve(
@@ -167,12 +167,4 @@ public class ExcelGenerator {
     }
     return false;
   }
-
-  private long getNumberOfNonEmptyCells(Row row) {
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(row.cellIterator(), Spliterator.ORDERED), false)
-        .map(Cell::getStringCellValue)
-        .filter(cellValue -> !cellValue.isBlank())
-        .count();
-  }
-
 }

--- a/src/main/java/com/docutools/jocument/impl/excel/util/ExcelUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/util/ExcelUtils.java
@@ -99,11 +99,34 @@ public class ExcelUtils {
     return false;
   }
 
-  private static long getNumberOfNonEmptyCells(Row row) {
+  /**
+   * Get the nuber of cells which are not empty in a row.
+   *
+   * @param row The row to check
+   * @return The number of cells in the row which contain a value
+   */
+  public static long getNumberOfNonEmptyCells(Row row) {
     return StreamSupport.stream(Spliterators.spliteratorUnknownSize(row.cellIterator(), Spliterator.ORDERED), false)
-        .map(Cell::getStringCellValue)
+        .map(ExcelUtils::getCellContentAsString)
         .filter(cellValue -> !cellValue.isBlank())
         .count();
+  }
+
+  /**
+   * Get the content of a cell as string representation.
+   *
+   * @param cell The cell to get the content from
+   * @return The cells content if present, else the blank string ""
+   */
+  public static String getCellContentAsString(Cell cell) {
+    return switch (cell.getCellType()) {
+      case NUMERIC -> String.valueOf(cell.getNumericCellValue());
+      case STRING -> cell.getStringCellValue();
+      case FORMULA -> cell.getCellFormula();
+      case BOOLEAN -> String.valueOf(cell.getBooleanCellValue());
+      case ERROR -> String.valueOf(cell.getErrorCellValue());
+      default -> "";
+    };
   }
 
   /**


### PR DESCRIPTION
Up until now, the function counting full cells did only work
for cells containing string values, not of other types
This commit fixes this by creating a new function which
retrieves the content of a cell as string value.

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>