### PR TITLE
Run checking workflow on any branch

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,5 @@
 name: Check code
-on:
-  push:
-    branches:
-      - master
+on: [push]
 
 jobs:
   checkstyle:


### PR DESCRIPTION
We decided to change the github workflow so that the
checking action workflow runs on any push to any branch,
release is still only done for the master branch

Signed-off-by: Anton Oellerer <a.oellerer@docu-tools.com>