### PR TITLE
Update javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ tasks.withType(JavaCompile) {
 
 java {
     withSourcesJar()
+    withJavadocJar()
 }
 
 test {

--- a/src/main/java/com/docutools/jocument/Document.java
+++ b/src/main/java/com/docutools/jocument/Document.java
@@ -2,11 +2,49 @@ package com.docutools.jocument;
 
 import java.nio.file.Path;
 
+/**
+ * This interface defines the publicly accessible methods of documents,
+ * which are created by starting the document generation from a
+ * {@link Template}.
+ * As one can see, they are mainly responsible for the monitoring of the
+ * thread generating the finished document from the template, one can
+ * only interact passively with the class.
+ *
+ * @author codecitizen
+ * @see Template
+ * @since 2020-02-19
+ */
 public interface Document {
 
+  /**
+   * This method is used to stop execution on the main thread until the
+   * generation of the document has finished or a specified time has passed,
+   * after which the thread responsible for generation gets interrupted.
+   *
+   * @param time the time to wait before interrupting the process in milliseconds
+   * @throws InterruptedException If document generation has not finished in the
+   *                              allowed time.
+   */
   void blockUntilCompletion(long time) throws InterruptedException;
 
+  /**
+   * Check if the document generation has completed.
+   * The `completed` boolean gets set to true if the
+   * generation has finished.
+   * If the threads get interrupted, it is not set, so
+   * this method would return false.
+   *
+   * @return Whether the document has been generated successfully
+   */
   boolean completed();
 
+  /**
+   * Get the path to the generated document.
+   * This is currently set only after the document generation
+   * has finished, but is dependant on the implementation, so this
+   * could change in the future.
+   *
+   * @return The path to the finished document
+   */
   Path getPath();
 }

--- a/src/main/java/com/docutools/jocument/MimeType.java
+++ b/src/main/java/com/docutools/jocument/MimeType.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 /**
  * The supported MIME-Types for {@link com.docutools.jocument.Template}s.
  *
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public enum MimeType {
   DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),

--- a/src/main/java/com/docutools/jocument/PlaceholderData.java
+++ b/src/main/java/com/docutools/jocument/PlaceholderData.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
  *
  * @author codecitzen
  * @see com.docutools.jocument.PlaceholderResolver
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public interface PlaceholderData {
 

--- a/src/main/java/com/docutools/jocument/PlaceholderResolver.java
+++ b/src/main/java/com/docutools/jocument/PlaceholderResolver.java
@@ -11,7 +11,7 @@ import org.apache.poi.util.LocaleUtil;
  * @author codecitizen
  * @see com.docutools.jocument.PlaceholderData
  * @see Document
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public interface PlaceholderResolver {
 

--- a/src/main/java/com/docutools/jocument/PlaceholderType.java
+++ b/src/main/java/com/docutools/jocument/PlaceholderType.java
@@ -5,7 +5,7 @@ package com.docutools.jocument;
  *
  * @author codecitizen
  * @see com.docutools.jocument.PlaceholderData
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public enum PlaceholderType {
   /**

--- a/src/main/java/com/docutools/jocument/Template.java
+++ b/src/main/java/com/docutools/jocument/Template.java
@@ -24,7 +24,7 @@ import org.apache.poi.util.LocaleUtil;
  * @see com.docutools.jocument.MimeType
  * @see com.docutools.jocument.PlaceholderResolver
  * @see Document
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public interface Template {
 

--- a/src/main/java/com/docutools/jocument/annotations/Format.java
+++ b/src/main/java/com/docutools/jocument/annotations/Format.java
@@ -17,7 +17,7 @@ import java.lang.annotation.RetentionPolicy;
  * @see java.time.LocalDateTime
  * @see java.time.LocalDate
  * @see java.time.ZonedDateTime
- * @since 28.02.2020
+ * @since 2020-02-28
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Format {

--- a/src/main/java/com/docutools/jocument/annotations/Image.java
+++ b/src/main/java/com/docutools/jocument/annotations/Image.java
@@ -9,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
  *
  * @author codecitizen
  * @see com.docutools.jocument.impl.ReflectionResolver
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Image {

--- a/src/main/java/com/docutools/jocument/impl/JsonResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/JsonResolver.java
@@ -34,7 +34,7 @@ import org.apache.tika.mime.MediaType;
  *
  * @author betorcs
  * @see com.docutools.jocument.PlaceholderResolver
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public class JsonResolver implements PlaceholderResolver {
   private static final Logger logger = LogManager.getLogger();

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author codecitizen
  * @see com.docutools.jocument.PlaceholderResolver
- * @since 1.0-SNAPSHOT
+ * @since 2020-02-19
  */
 public class ReflectionResolver implements PlaceholderResolver {
 

--- a/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelDocumentImpl.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelDocumentImpl.java
@@ -22,8 +22,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
  * and for passing each sheet of a workbook to the excel generator.
  *
  * @author Anton Oellerer
- * @version 1.1.0
- * @since 2020-04
+ * @since 2020-04-07
  */
 public class ExcelDocumentImpl extends DocumentImpl {
   private static final Logger logger = LogManager.getLogger();

--- a/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/implementations/ExcelGenerator.java
@@ -27,8 +27,7 @@ import org.apache.poi.ss.usermodel.Row;
  * Because of this, the generator is agnostic of enclosing structures like sheets and workbooks.
  *
  * @author Anton Oellerer
- * @version 1.1.0
- * @since 2020-04
+ * @since 2020-04-10
  */
 public class ExcelGenerator {
   private static final Logger logger = LogManager.getLogger();

--- a/src/main/java/com/docutools/jocument/impl/excel/implementations/SXSSFWriter.java
+++ b/src/main/java/com/docutools/jocument/impl/excel/implementations/SXSSFWriter.java
@@ -25,8 +25,7 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
  * to be created.
  *
  * @author Anton Oellerer
- * @version 1.1.0
- * @since 2020-05
+ * @since 2020-04-02
  */
 public class SXSSFWriter implements ExcelWriter {
   private static final Logger logger = LogManager.getLogger();


### PR DESCRIPTION
To make jocument more accessible, this branch updates and streamlines the javadocs.
Additionally, the javadoc jar is now released as well.


Closes #31 