### PR TITLE
Fix image resolver test

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,7 +57,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Install libvips
-        run: apt-get install -y libvips42
+        run: sudo apt-get install -y libvips42
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,6 +56,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Install libvips
+        run: apt-get install -y libvips42
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Java

--- a/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
+++ b/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
@@ -162,7 +162,7 @@ class WordGeneratorTest {
 
         // Act
         Document document = template.startGeneration(resolver);
-        document.blockUntilCompletion(60000L); // 1 minute
+        document.blockUntilCompletion(120000L); // 2 minutes
 
         // Assert
         assertThat(document.completed(), is(true));

--- a/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
+++ b/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
@@ -162,7 +162,7 @@ class WordGeneratorTest {
 
         // Act
         Document document = template.startGeneration(resolver);
-        document.blockUntilCompletion(120000L); // 2 minutes
+        document.blockUntilCompletion(60000L); // 1 minute
 
         // Assert
         assertThat(document.completed(), is(true));


### PR DESCRIPTION
The image resolver test failed since libvips was not installed on the machine.
This commit fixes this by installing libvips in the testing action