### PR TITLE
Upgrade to apache poi 5.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.2.10'
+version = '1.2.11'
 
 sourceCompatibility = 17
 targetCompatibility = 17
@@ -24,7 +24,7 @@ repositories {
     }
 }
 
-def apachePOIVersion = '5.0.0'
+def apachePOIVersion = '5.1.0'
 
 dependencies {
     implementation('commons-beanutils:commons-beanutils:1.9.4')
@@ -44,7 +44,7 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.8.1')
     testImplementation("org.hamcrest:hamcrest:2.2")
-    testImplementation("com.docutools:poipath:1.1.4")
+    testImplementation("com.docutools:poipath:1.1.5")
 }
 
 tasks.withType(Checkstyle) {

--- a/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
@@ -17,8 +17,6 @@ import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.xwpf.usermodel.IBodyElement;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
-import org.apache.poi.xwpf.usermodel.XWPFTableCell;
-import org.apache.poi.xwpf.usermodel.XWPFTableRow;
 
 class WordGenerator {
   private static final Logger logger = LogManager.getLogger();
@@ -70,10 +68,9 @@ class WordGenerator {
   private void transform(XWPFTable table) {
     table.getRows()
         .stream()
-        .map(XWPFTableRow::getTableCells)
-        .flatMap(List::stream)
-        .map(XWPFTableCell::getParagraphs)
-        .flatMap(List::stream)
+        .flatMap(xwpfTableRow -> xwpfTableRow.getTableCells().stream())
+        .flatMap(xwpfTableCell -> xwpfTableCell.getParagraphs().stream())
+        .filter(xwpfParagraph -> !xwpfParagraph.isEmpty())
         .forEach(this::transform);
     logger.debug("Transformed table {}", table);
   }

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -325,6 +325,10 @@ public class WordUtilities {
               ctTcPr = ctTc.addNewTcPr();
             }
             ctTcPr.set(cell.getCTTc().getTcPr());
+            if (newCell.getParagraphs().size() > 0) {
+              // The new cell might be created with empty paragraphs which we do not need, so we remove them here
+              IntStream.range(0, newCell.getParagraphs().size()).forEach(value -> newCell.removeParagraph(0));
+            }
             cell.getParagraphs()
                 .forEach(paragraph -> {
                   XWPFParagraph newParagraph = newCell.addParagraph();


### PR DESCRIPTION
Apache poi 5.1.0 has been released, fixing a
number of insecurities.
Along with it a few changes to the library
have been done, to keep expected behaviour
`cloneTable` is updated to remove empty
paragraphs from newly created cells.
In line with this, poipath is upgraded as
well.