### PR TITLE
Remove EnricoMi/publish-unit-test-results

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -74,12 +74,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: automatedTests
-      - name: Publish test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v1.23
-        with:
-          report_individual_runs: true
-          files: build/test-results/automatedTests/*.xml
       - name: Archive test results
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
The publishing of unit test results led to
complications, and is not necessary since they
are uploaded as artifacts anyways.