### PR TITLE
Implement reflection resolving for records

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.2.13'
+version = '1.3.0'
 
 sourceCompatibility = 17
 targetCompatibility = 17

--- a/src/test/java/com/docutools/jocument/sample/model/SampleModelData.java
+++ b/src/test/java/com/docutools/jocument/sample/model/SampleModelData.java
@@ -5,26 +5,30 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 public class SampleModelData {
 
   public static final Captain PICARD;
   public static final Person PICARD_PERSON = new Person("Jean-Luc", "Picard", LocalDate.of(1948, 9, 23));
   public static final List<Captain> CAPTAINS;
+  public static final Ship ENTERPRISE;
 
   static {
     try {
+      var services = List.of(new Service("USS Enterprise", Collections.singletonList(
+              new PlanetServiceInfo("Mars", Collections.singletonList(new City("Nova Rojava"))))),
+          new Service("US Defiant", List.of(
+              new PlanetServiceInfo("Venus", List.of(new City("Nova Parisia"), new City("Birnin Zana"))),
+              new PlanetServiceInfo("Jupiter", List.of(new City("Exarcheia"), new City("Nova Metalkova"))))));
       PICARD = new Captain("Jean-Luc Picard",
           4,
           Uniform.Red,
           new FirstOfficer("Riker", 3, Uniform.Red),
-          List.of(new Service("USS Enterprise", Collections.singletonList(
-              new PlanetServiceInfo("Mars", Collections.singletonList(new City("Nova Rojava"))))),
-              new Service("US Defiant", List.of(
-                  new PlanetServiceInfo("Venus", List.of(new City("Nova Parisia"), new City("Birnin Zana"))),
-                  new PlanetServiceInfo("Jupiter", List.of(new City("Exarcheia"), new City("Nova Metalkova")))))),
+          services,
           Path.of(SampleModelData.class.getResource("/images/picardProfile.jpg").toURI()));
       CAPTAINS = List.of(PICARD);
+      ENTERPRISE = new Ship("USS Enterprise", PICARD, 5, services, LocalDate.now());
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/docutools/jocument/sample/model/Ship.java
+++ b/src/test/java/com/docutools/jocument/sample/model/Ship.java
@@ -1,0 +1,7 @@
+package com.docutools.jocument.sample.model;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record Ship(String name, Captain captain, int crew, List<Service> services, LocalDate built) {
+}


### PR DESCRIPTION
Apache BeanUtils only works with Classes, not
with records.
This commit adds the logic to deal with
records handed to the ReflectionResolver.