### PR TITLE
Strip paragraphs for loop checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.5.0'
+version = '1.5.1'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordGenerator.java
@@ -116,7 +116,7 @@ class WordGenerator {
     return remaining.stream()
         //Could be written nice with `takeUntil(element -> (element instanceof XP xp && eLM.equals(WU.toString(xp)))
         .takeWhile(element -> !(element instanceof XWPFParagraph xwpfParagraph
-            && endLoopMarkers.stream().anyMatch(endLoopMarker -> endLoopMarker.equals(WordUtilities.toString(xwpfParagraph)))))
+            && endLoopMarkers.stream().anyMatch(endLoopMarker -> endLoopMarker.equals(WordUtilities.toString(xwpfParagraph).strip()))))
         .toList();
   }
 


### PR DESCRIPTION
Up until now, paragraphs were not stripped from
whitespace before checking whether they were loop
terminators.