### PR TITLE
Allow using @Translatable on objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.5.6-beta.1'
+version = '1.5.7-alpha.1'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/docutools/jocument/annotations/Translatable.java
+++ b/src/main/java/com/docutools/jocument/annotations/Translatable.java
@@ -5,4 +5,10 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Translatable {
+  /**
+   * Specify the method which should be applied to retrieve a (translatable) string from the annotated object.
+   *
+   * @return The name of the method to use to retrieve the string which should be translated from objects
+   */
+  String toStringMethod() default "toString";
 }

--- a/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
@@ -5,7 +5,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import com.docutools.jocument.impl.CustomPlaceholderRegistryImpl;
 import com.docutools.jocument.impl.ReflectionResolver;
+import com.docutools.jocument.sample.model.Person;
 import com.docutools.jocument.sample.model.SampleModelData;
 import com.docutools.jocument.sample.model.Ship;
 import com.docutools.jocument.sample.model.Uniform;
@@ -252,5 +254,24 @@ class ReflectionResolvingTests {
 
     // Assert
     assertThat(position.isEmpty(), equalTo(true));
+  }
+
+  @Test
+  void shouldTranslateShipName() {
+    Person picardPerson = SampleModelData.PICARD_PERSON;
+    picardPerson.setFavouriteShip(SampleModelData.ENTERPRISE);
+    GenerationOptions generationOptions = new GenerationOptionsBuilder()
+        .withTranslation((s, locale) -> {
+          if (s.equals("USS Enterprise")) {
+            return Optional.of("VSS Unternehmung");
+          } else {
+            return Optional.empty();
+          }
+        }).build();
+    var resolver = new ReflectionResolver(picardPerson, new CustomPlaceholderRegistryImpl(), generationOptions);
+
+    var shipName = resolver.resolve("favouriteShip");
+
+    assertThat(shipName.get().toString(), equalTo("VSS Unternehmung"));
   }
 }

--- a/src/test/java/com/docutools/jocument/sample/model/Person.java
+++ b/src/test/java/com/docutools/jocument/sample/model/Person.java
@@ -1,6 +1,7 @@
 package com.docutools.jocument.sample.model;
 
 import com.docutools.jocument.annotations.Format;
+import com.docutools.jocument.annotations.Translatable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
@@ -13,6 +14,8 @@ public class Person {
   @Format(value = "dd.MM.yyyy")
   private final LocalDate birthDate;
   private final Instant entryDate;
+  @Translatable(toStringMethod = "shipName")
+  private Ship favouriteShip;
 
   public Person(String firstName, String lastName, LocalDate birthDate) {
     this.firstName = firstName;
@@ -43,5 +46,13 @@ public class Person {
 
   public Instant getEntryDate() {
     return entryDate;
+  }
+
+  public void setFavouriteShip(Ship favouriteShip) {
+    this.favouriteShip = favouriteShip;
+  }
+
+  public Ship getFavouriteShip() {
+    return favouriteShip;
   }
 }

--- a/src/test/java/com/docutools/jocument/sample/model/Ship.java
+++ b/src/test/java/com/docutools/jocument/sample/model/Ship.java
@@ -32,4 +32,7 @@ public record Ship(String name, Captain captain, int crew, List<Service> service
     return Optional.of(String.valueOf(services.size()));
   }
 
+  public String shipName() {
+    return this.name;
+  }
 }


### PR DESCRIPTION
Up until now, the `@Translatable` annotation
only worked on Strings and Enums.
To be able to also specify more complex objects as
translatable, the annotation is extended by an
optional `toStringMethod` which is used to retrieve
a string value to translate for those objects.

Merge after #170 