### PR TITLE
Resolve UUID to `ScalarPlaceholder<String>`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.5.7-alpha.1'
+version = '1.5.8-alpha.2'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -35,6 +35,7 @@ import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -401,6 +402,8 @@ public class ReflectionResolver extends PlaceholderResolver {
     } else if (property instanceof Path path && isFieldAnnotatedWith(bean.getClass(), placeholderName, Image.class)) {
       return ReflectionUtils.findFieldAnnotation(bean.getClass(), placeholderName, Image.class)
           .map(image -> new ImagePlaceholderData(path).withMaxWidth(image.maxWidth()));
+    } else if (property instanceof UUID uuid) {
+      return Optional.of(new ScalarPlaceholderData<>(uuid.toString()));
     } else {
       return Optional.empty();
     }

--- a/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
@@ -274,4 +274,14 @@ class ReflectionResolvingTests {
 
     assertThat(shipName.get().toString(), equalTo("VSS Unternehmung"));
   }
+
+  @Test
+  void shouldResolveUUIDtoString() {
+    Person picardPerson = SampleModelData.PICARD_PERSON;
+    var resolver = new ReflectionResolver(picardPerson);
+
+    var id = resolver.resolve("id");
+
+    assertThat(id.get().toString(), equalTo(picardPerson.getId().toString()));
+  }
 }

--- a/src/test/java/com/docutools/jocument/sample/model/Person.java
+++ b/src/test/java/com/docutools/jocument/sample/model/Person.java
@@ -6,8 +6,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneOffset;
+import java.util.UUID;
 
 public class Person {
+  private final UUID id = UUID.randomUUID();
 
   private final String firstName;
   private final String lastName;
@@ -54,5 +56,9 @@ public class Person {
 
   public Ship getFavouriteShip() {
     return favouriteShip;
+  }
+
+  public UUID getId() {
+    return id;
   }
 }


### PR DESCRIPTION
To be able to simply represent UUIDs, when resolving one, a `ScalarPlaceholder` containing its string
representation is returned.