### PR TITLE
Return empty string if field is null

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,7 +64,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Install libvips
-        run: sudo apt-get install -y libvips42
+        run: sudo apt-get update && sudo apt-get install -y libvips42
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Java

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.5.11'
+version = '1.5.12'
 
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -333,8 +333,7 @@ public class ReflectionResolver extends PlaceholderResolver {
       }
       var wrappedProperty = getBeanProperty(placeholderName);
       if (wrappedProperty.isEmpty()) {
-        logger.debug("Placeholder {} could not be translated into a property", placeholderName);
-        return Optional.empty();
+        return Optional.of(new ScalarPlaceholderData<>(null));
       }
       var property = resolveNonFinalValue(wrappedProperty.get(), placeholderName);
       var simplePlaceholder = resolveSimplePlaceholder(property, placeholderName, locale, options);

--- a/src/main/java/com/docutools/jocument/impl/ScalarPlaceholderData.java
+++ b/src/main/java/com/docutools/jocument/impl/ScalarPlaceholderData.java
@@ -13,7 +13,7 @@ public class ScalarPlaceholderData<T> implements PlaceholderData {
   private final Function<T, String> stringifier;
 
   public ScalarPlaceholderData(T value) {
-    this(value, Objects::toString);
+    this(value, v -> Objects.toString(v, ""));
   }
 
   public ScalarPlaceholderData(T value, Function<T, String> stringifier) {

--- a/src/main/java/com/docutools/jocument/impl/word/WordImageUtils.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordImageUtils.java
@@ -60,6 +60,7 @@ public class WordImageUtils {
     var contentType = probeImageType(path);
 
     try (var in = Files.newInputStream(path, StandardOpenOption.READ)) {
+      logger.debug("Adding picture from path {} with content type {} and dimensions {} {}", path, contentType, dim.width, dim.height);
       return paragraph.createRun()
           .addPicture(in, contentType, path.getFileName().toString(), dim.width, dim.height);
     } catch (InvalidFormatException | IOException e) {

--- a/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
@@ -284,4 +284,15 @@ class ReflectionResolvingTests {
 
     assertThat(id.get().toString(), equalTo(picardPerson.getId().toString()));
   }
+
+  @Test
+  void shouldResolveNullToEmptyString() {
+    Person picardPerson = SampleModelData.PICARD_NULL;
+    var resolver = new ReflectionResolver(picardPerson);
+
+    var name = resolver.resolve("firstName");
+
+    assertThat(name.get().toString(), equalTo(""));
+  }
+
 }

--- a/src/test/java/com/docutools/jocument/sample/model/SampleModelData.java
+++ b/src/test/java/com/docutools/jocument/sample/model/SampleModelData.java
@@ -13,6 +13,7 @@ public class SampleModelData {
   public static final Captain PICARD;
   public static final FutureCaptain FUTURE_PICARD;
   public static final Person PICARD_PERSON = new Person("Jean-Luc", "Picard", LocalDate.of(1948, 9, 23));
+  public static final Person PICARD_NULL = new Person(null, "Picard", LocalDate.of(1948, 9, 23));
   public static final List<Captain> CAPTAINS;
   public static final Ship ENTERPRISE;
   public static final Ship ENTERPRISE_WITHOUT_SERVICES;


### PR DESCRIPTION
Up until now, if during reflection resolving a field was null, the resolver continued search further up the object tree. This should not happen, as a field being null also constitutes information.
To fix this, from now on a `ScalarPlaceholderData(null)` is returned, with the default formatting of null being the empty string.