### PR TITLE
Add new "DynamicAccess" Annotation for RR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '1.7.0'
+version = '1.8.0'
 
 java {
     toolchain {
@@ -80,10 +80,12 @@ test {
     useJUnitPlatform()
 }
 
-task automatedTests(type: Test) {
+tasks.register('automatedTests', Test) {
+    testClassesDirs = testing.suites.test.sources.output.classesDirs
+    classpath = testing.suites.test.sources.runtimeClasspath
     environment 'DT_JT_RR_PLACEHOLDER_MAPPINGS', 'src/test/resources/mappings.txt'
-    useJUnitPlatform{
-        includeTags "automated"
+    useJUnitPlatform {
+        includeTags 'automated'
     }
 }
 

--- a/src/main/java/com/docutools/jocument/annotations/MatchPlaceholder.java
+++ b/src/main/java/com/docutools/jocument/annotations/MatchPlaceholder.java
@@ -1,5 +1,6 @@
 package com.docutools.jocument.annotations;
 
+import com.docutools.jocument.impl.models.MatchPlaceholderData;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Locale;
@@ -11,8 +12,7 @@ import java.util.Locale;
  *
  * <p>{@link MatchPlaceholder}-annotated methods precede any other properties.
  *
- * <p>Can be applied to a public method taking a {@link String} and an optional {@link java.util.Locale} as second parameter, returning an {@link
- * java.util.Optional} of {@link String}.
+ * <p>Can be applied to a public method taking a {@link MatchPlaceholderData}, returning an {@link java.util.Optional} of {@link String}.
  *
  * @author amp
  * @since 2022-03-01

--- a/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
+++ b/src/test/java/com/docutools/jocument/impl/word/WordGeneratorTest.java
@@ -492,4 +492,24 @@ class WordGeneratorTest {
         assertThat(documentWrapper.bodyElement(0).asParagraph().run(0).text(),
             equalTo("Live your life not celebrating victories, but overcoming defeats."));
     }
+
+    @Test
+    void dynamicAccess() throws InterruptedException, IOException {
+        // assemble
+        Template template = Template.fromClassPath("/templates/word/DynamicAccess.docx")
+            .orElseThrow();
+        SampleModelData.PICARD_PERSON.setFavouriteShip(SampleModelData.ENTERPRISE);
+        PlaceholderResolver resolver = new ReflectionResolver(SampleModelData.PICARD_PERSON);
+
+        // act
+        Document document = template.startGeneration(resolver);
+        document.blockUntilCompletion(60000L); // 1 minute
+
+        // assert
+        assertThat(document.completed(), is(true));
+        xwpfDocument = TestUtils.getXWPFDocumentFromDocument(document);
+        var documentWrapper = new XWPFDocumentWrapper(xwpfDocument);
+        assertThat(documentWrapper.bodyElement(0).asParagraph().run(0).text(), equalTo(SampleModelData.ENTERPRISE.name()));
+    }
+
 }

--- a/src/test/java/com/docutools/jocument/sample/model/Person.java
+++ b/src/test/java/com/docutools/jocument/sample/model/Person.java
@@ -1,11 +1,14 @@
 package com.docutools.jocument.sample.model;
 
+import com.docutools.jocument.annotations.DynamicAccessPlaceholder;
 import com.docutools.jocument.annotations.Format;
 import com.docutools.jocument.annotations.Translatable;
+import com.docutools.jocument.impl.models.MatchPlaceholderData;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import java.util.UUID;
 
 public class Person {
@@ -60,5 +63,10 @@ public class Person {
 
   public UUID getId() {
     return id;
+  }
+
+  @DynamicAccessPlaceholder(pattern = "last-used-ship")
+  public Optional<Ship> getLastUsedShip(MatchPlaceholderData matchPlaceholderData) {
+    return Optional.ofNullable(this.favouriteShip);
   }
 }


### PR DESCRIPTION
To allow the `ReflectionResolver` to resolve objects dynamically (meaning that they could not be resolved at compilation time), a new `DynamicAccessPlaceholder` Annotation is added. Methods annotated by it return an `Optional<Object>`, which is then used by the resolver to create a new `PlaceholderData` for further resolving.