### PR TITLE
Use "-" to signal null fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '4.2.4'
+version = '4.2.5'
 
 java {
     toolchain {

--- a/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
+++ b/src/main/java/com/docutools/jocument/impl/ReflectionResolver.java
@@ -391,7 +391,7 @@ public class ReflectionResolver extends PlaceholderResolver {
       }
       var wrappedProperty = getBeanProperty(placeholderName);
       if (wrappedProperty.isEmpty()) {
-        return Optional.of(new ScalarPlaceholderData<>(null));
+        return Optional.of(new ScalarPlaceholderData<>("-"));
       }
       return toPlaceholderData(placeholderName, locale, wrappedProperty.get());
     } catch (NoSuchMethodException | IllegalArgumentException e) {
@@ -502,12 +502,11 @@ public class ReflectionResolver extends PlaceholderResolver {
   }
 
   private Optional<Object> getBeanProperty(String placeholderName) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-    var ignoreCasePlaceholder = placeholderName.toLowerCase();
     if (SELF_REFERENCE.equals(placeholderName)) {
       return Optional.ofNullable(bean);
     } else if (bean.getClass().isRecord()) {
       var accessor = Arrays.stream(bean.getClass().getRecordComponents())
-          .filter(recordComponent -> recordComponent.getName().toLowerCase().equals(ignoreCasePlaceholder))
+          .filter(recordComponent -> recordComponent.getName().equalsIgnoreCase(placeholderName))
           .map(RecordComponent::getAccessor)
           .findFirst()
           .orElseThrow(() -> new NoSuchMethodException("Record %s does not have field %s".formatted(bean.getClass().toString(), placeholderName)));

--- a/src/main/java/com/docutools/jocument/impl/ScalarPlaceholderData.java
+++ b/src/main/java/com/docutools/jocument/impl/ScalarPlaceholderData.java
@@ -42,7 +42,7 @@ public class ScalarPlaceholderData<T> implements PlaceholderData {
     if (value instanceof Number number) {
       return number.longValue() != 0L;
     } else if (value instanceof String string) {
-      return !string.isEmpty();
+      return !string.isEmpty() && !string.equals("-");
     } else if (value instanceof Boolean bool) {
       return bool;
     } else if (value instanceof Collection<?> collection) {

--- a/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
+++ b/src/test/java/com/docutools/jocument/ReflectionResolvingTests.java
@@ -288,13 +288,13 @@ class ReflectionResolvingTests {
   }
 
   @Test
-  void shouldResolveNullToEmptyString() {
+  void shouldResolveNullToMinus() {
     Person picardPerson = SampleModelData.PICARD_NULL;
     var resolver = new ReflectionResolver(picardPerson);
 
     var name = resolver.resolve("firstName");
 
-    assertThat(name.get().toString(), equalTo(""));
+    assertThat(name.get().toString(), equalTo("-"));
   }
 
   @Test


### PR DESCRIPTION
To be able to see that a fields
value was `null`, "-" is used as
the placeholder substitution value