### PR TITLE
Fix run text removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.docutools'
-version = '4.2.6'
+version = '4.2.7'
 
 java {
     toolchain {

--- a/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
+++ b/src/main/java/com/docutools/jocument/impl/word/WordUtilities.java
@@ -32,6 +32,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTbl;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTblPr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTc;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTcPr;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTText;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTrPr;
 
 public class WordUtilities {
@@ -67,14 +68,11 @@ public class WordUtilities {
     // When deleting a run from a paragraph, the collection keeping the runs shrinks to fit to the new size
     // If we delete the runs with indices 1,2,3...,x,  the second half of the delete operations fails silently
     // To avoid this, we simply delete the first run x times.
-    IntStream.range(1, runs.size()).forEach(value -> paragraph.removeRun(0));
+    IntStream.range(1, runs.size()).forEach(value -> paragraph.removeRun(1));
   }
 
   private static void removeRunText(XWPFRun run) {
-    int sizeOfTextArray = run.getCTR().sizeOfTArray();
-    for (int i = 0; i < sizeOfTextArray; i++) {
-      run.setText("", i);
-    }
+    run.getCTR().setTArray(new CTText[]{});
   }
 
   private static void insertLines(String[] lines, XWPFRun run) {


### PR DESCRIPTION
In 0d0a6adc, a bug was introduced where
paragraph and run text was removed
incorrectly.
This commit fixes this by correctly
setting the removal index and replacing
the run text array.